### PR TITLE
Fire callbacks of all calls to setState

### DIFF
--- a/lib/Ratestate.js
+++ b/lib/Ratestate.js
@@ -116,7 +116,7 @@
                 _results = [];
                 for (_j = 0, _len = cbs.length; _j < _len; _j++) {
                   cb = cbs[_j];
-                  _results.push(cb(err));
+                  _results.push(cb(err, desiredState));
                 }
                 return _results;
               }

--- a/src/Ratestate.coffee
+++ b/src/Ratestate.coffee
@@ -110,7 +110,7 @@ class Ratestate
           # execute all callbacks that have been queued up
           if cbs?
             for cb in cbs
-              cb err
+              cb err, desiredState
 
         return
 


### PR DESCRIPTION
If someone provides a callback to a setState call, she/he relies on it getting executed, even if the write of the setState was skipped due to the ratelimiter. Callbacks should receive the state that was last written so that calling code knows what the current actual state is, and if it's the one from the setState() call that the calling code made, or from a later call to setState().
